### PR TITLE
Re-export from `GHC.Classes` (with GHC 9.10+)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.2
+# version: 0.19.20240501
 #
-# REGENDATA ("0.16.2",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20240501",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,24 +23,34 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.10.0.20240426
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.10.0.20240426
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.8.2
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.6.5
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.8
+            compilerKind: ghc
+            compilerVersion: 9.4.8
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -56,64 +66,40 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -125,25 +111,18 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -172,6 +151,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -195,7 +186,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -234,6 +225,9 @@ jobs:
           package generator-script
             ghc-options: -Werror
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(constraint-tuples|generator-script)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -242,7 +236,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -264,7 +258,7 @@ jobs:
         run: |
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## next [????.??.??]
+* Drop support for GHC 7.10 and earlier.
 * Provide constraint tuples up to size 64 when building with GHC 9.2 or later.
   (Earlier versions of GHC impose a maximum tuple size of 62.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## next [????.??.??]
 * Drop support for GHC 7.10 and earlier.
+* Provide nullary constraint tuples named `CUnit` and unary constraint tuples
+  named `CSolo` for consistency with `GHC.Classes` in GHC 9.10+.
 * Provide constraint tuples up to size 64 when building with GHC 9.2 or later.
   (Earlier versions of GHC impose a maximum tuple size of 62.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next [????.??.??]
 * Drop support for GHC 7.10 and earlier.
+* When building with GHC 9.10 or later, `Data.Tuple.Constraint` will simply
+  re-export constraint tuple definitions found in `GHC.Classes`. If building
+  with an older version of GHC, `Data.Tuple.Constraint` will backport the
+  definitions from `GHC.Classes.
 * Provide nullary constraint tuples named `CUnit` and unary constraint tuples
   named `CSolo` for consistency with `GHC.Classes` in GHC 9.10+.
 * Provide constraint tuples up to size 64 when building with GHC 9.2 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next [????.??.??]
+* Provide constraint tuples up to size 64 when building with GHC 9.2 or later.
+  (Earlier versions of GHC impose a maximum tuple size of 62.)
+
 ### 0.1.2 [2019.11.24]
 * Introduce the `Data.Tuple.Constraint.{TypeFamily,TypeSynonym}` modules that
   provide ways of directly accessing constraint tuple type constructors through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## next [????.??.??]
+## 0.2 [????.??.??]
 * Drop support for GHC 7.10 and earlier.
 * When building with GHC 9.10 or later, `Data.Tuple.Constraint` will simply
   re-export constraint tuple definitions found in `GHC.Classes`. If building

--- a/README.md
+++ b/README.md
@@ -32,6 +32,4 @@ API with slight differences in their implementation:
   type family axiom.
 * `Data.Tuple.Constraint.TypeSynonym`: A `CTupleN` type alias is a constraint
   tuple type constructor with `N` arguments obtained by way of a type synonym.
-  This will compile directly to a built-in constraint tuple, but because this
-  requires use of GHC features only present on 8.0 or later, this module does
-  not export anything on earlier versions of GHC.
+  This will compile directly to a built-in constraint tuple.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ This library exposes four different modules that provide essentially the same
 API with slight differences in their implementation:
 
 * `Data.Tuple.Constraint`: A `CTupleN` class compiles to a dictionary data type
-   with `N` fields.
+   with `N` fields. (When building with GHC 9.10 or later, this will simply
+   re-export the constraint tuples offered by `GHC.Classes`.)
 * `Data.Tuple.Constraint.ClassNewtype`: A `CTupleN` class compiles to a newtype
    around the corresponding built-in constraint tuple type with `N` arguments.
 * `Data.Tuple.Constraint.TypeFamily`: A `CTupleN` type alias is a constraint

--- a/constraint-tuples.cabal
+++ b/constraint-tuples.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                constraint-tuples
-version:             0.1.2
+version:             0.2
 synopsis:            Partially applicable constraint tuples
 description:         This library provides classes and type aliases that
                      emulate the behavior of GHC's constraint tuple syntax.
@@ -69,6 +69,7 @@ library
                        Data.Tuple.Constraint.TypeFamily
                        Data.Tuple.Constraint.TypeSynonym
   build-depends:       base >= 4.9 && < 5
+                     , ghc-prim
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/constraint-tuples.cabal
+++ b/constraint-tuples.cabal
@@ -18,19 +18,16 @@ description:         This library provides classes and type aliases that
                        compiles to a newtype around the corresponding built-in
                        constraint tuple type with @N@ arguments.
                      .
-                     * @Data.Tuple.Constraint.TypeFamily@: A @CTupleN@ type
+                     * "Data.Tuple.Constraint.TypeFamily": A @CTupleN@ type
                        alias is a constraint tuple type constructor with @N@
                        arguments obtained by way of a type family. This will
                        compile to a built-in constraint tuple, but casted with
                        a type family axiom.
                      .
-                     * @Data.Tuple.Constraint.TypeSynonym@: A @CTupleN@ type
+                     * "Data.Tuple.Constraint.TypeSynonym": A @CTupleN@ type
                        alias is a constraint tuple type constructor with @N@
                        arguments obtained by way of a type synonym. This will
-                       compile directly to a built-in constraint tuple, but
-                       because this requires use of GHC features only present
-                       on 8.0 or later, this module does not export anything on
-                       earlier versions of GHC.
+                       compile directly to a built-in constraint tuple.
 homepage:            https://github.com/RyanGlScott/constraint-tuples
 bug-reports:         https://github.com/RyanGlScott/constraint-tuples/issues
 license:             BSD3
@@ -47,19 +44,18 @@ extra-source-files:  CHANGELOG.md
                      generator-script/LICENSE
                      generator-script/generator-script.cabal
                      generator-script/exe/GeneratorScript.hs
-tested-with:         GHC == 7.6.3
-                   , GHC == 7.8.4
-                   , GHC == 7.10.3
-                   , GHC == 8.0.2
+tested-with:         GHC == 8.0.2
                    , GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.5
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.7
-                   , GHC == 9.4.5
-                   , GHC == 9.6.1
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.5
+                   , GHC == 9.8.2
+                   , GHC == 9.10.1
 
 source-repository head
   type:                git
@@ -70,7 +66,7 @@ library
                        Data.Tuple.Constraint.ClassNewtype
                        Data.Tuple.Constraint.TypeFamily
                        Data.Tuple.Constraint.TypeSynonym
-  build-depends:       base >= 4.6 && < 5
+  build-depends:       base >= 4.9 && < 5
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/constraint-tuples.cabal
+++ b/constraint-tuples.cabal
@@ -12,7 +12,9 @@ description:         This library provides classes and type aliases that
                      implementation:
                      .
                      * "Data.Tuple.Constraint": A @CTupleN@ class compiles to
-                       a dictionary data type with @N@ fields.
+                       a dictionary data type with @N@ fields. (When building
+                       with GHC 9.10 or later, this will simply re-export the
+                       constraint tuples offered by "GHC.Classes".)
                      .
                      * "Data.Tuple.Constraint.ClassNewtype": A @CTupleN@ class
                        compiles to a newtype around the corresponding built-in

--- a/generator-script/generator-script.cabal
+++ b/generator-script/generator-script.cabal
@@ -16,19 +16,18 @@ stability:           Stable
 copyright:           (C) 2018-2019 Ryan Scott
 category:            Data
 build-type:          Simple
-tested-with:         GHC == 7.6.3
-                   , GHC == 7.8.4
-                   , GHC == 7.10.3
-                   , GHC == 8.0.2
+tested-with:         GHC == 8.0.2
                    , GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.5
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.7
-                   , GHC == 9.4.5
-                   , GHC == 9.6.1
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.5
+                   , GHC == 9.8.2
+                   , GHC == 9.10.1
 
 source-repository head
   type:                git
@@ -37,7 +36,7 @@ source-repository head
 
 executable generator-script
   main-is:             GeneratorScript.hs
-  build-depends:       base                  >= 4.6  && < 5
+  build-depends:       base                  >= 4.9  && < 5
                      , base-compat-batteries >= 0.10 && < 0.15
                      , optparse-applicative  >= 0.13 && < 0.19
   hs-source-dirs:      exe

--- a/src/Data/Tuple/Constraint.hs
+++ b/src/Data/Tuple/Constraint.hs
@@ -14,6 +14,8 @@ module Data.Tuple.Constraint
   ( -- * Constraint tuples
     CTuple0
   , CTuple1
+  , CUnit
+  , CSolo
   , CTuple2
   , CTuple3
   , CTuple4
@@ -83,15 +85,21 @@ module Data.Tuple.Constraint
 #endif
   ) where
 
+import Data.Kind (Constraint)
+
+-- | An alias for a nullary constraint tuple.
+type CTuple0 = (() :: Constraint)
+
+-- | An alias for a unary constraint tuple.
+type CTuple1 = CSolo
+
 -- | A constraint tuple class with 0 arguments.
---
--- This class is only defined on GHC 7.8 or later.
-class    () => CTuple0
-instance () => CTuple0
+class    () => CUnit
+instance () => CUnit
 
 -- | A constraint tuple class with 1 argument.
-class    c1 => CTuple1 c1
-instance c1 => CTuple1 c1
+class    c1 => CSolo c1
+instance c1 => CSolo c1
 
 -- | A constraint tuple class with 2 arguments.
 class    (c1, c2) => CTuple2 c1 c2

--- a/src/Data/Tuple/Constraint.hs
+++ b/src/Data/Tuple/Constraint.hs
@@ -82,6 +82,12 @@ module Data.Tuple.Constraint
   , CTuple60
   , CTuple61
   , CTuple62
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple63
+#endif
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple64
+#endif
   ) where
 
 #if __GLASGOW_HASKELL__ >= 708
@@ -339,4 +345,16 @@ instance (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16,
 -- | A constraint tuple class with 62 arguments.
 class    (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62) => CTuple62 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62
 instance (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62) => CTuple62 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A constraint tuple class with 63 arguments.
+class    (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63) => CTuple63 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63
+instance (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63) => CTuple63 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63
+#endif
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A constraint tuple class with 64 arguments.
+class    (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64) => CTuple64 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64
+instance (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64) => CTuple64 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64
+#endif
 

--- a/src/Data/Tuple/Constraint.hs
+++ b/src/Data/Tuple/Constraint.hs
@@ -10,6 +10,9 @@
 -- | This module provides classes that emulate the behavior of GHC's constraint
 -- tuple syntax. Unlike GHC's built-in constraint tuples, the classes in this
 -- library can be partially applied.
+--
+-- When building with GHC 9.10 or later, this will simply re-export the
+-- constraint tuples offered by "GHC.Classes".
 module Data.Tuple.Constraint
   ( -- * Constraint tuples
     CTuple0
@@ -85,7 +88,13 @@ module Data.Tuple.Constraint
 #endif
   ) where
 
+#if __GLASGOW_HASKELL__ >= 910
+import GHC.Classes
+#else
 import Data.Kind (Constraint)
+#endif
+
+#if __GLASGOW_HASKELL__ < 910
 
 -- | An alias for a nullary constraint tuple.
 type CTuple0 = (() :: Constraint)
@@ -357,3 +366,4 @@ class    (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16,
 instance (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64) => CTuple64 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64
 #endif
 
+#endif

--- a/src/Data/Tuple/Constraint.hs
+++ b/src/Data/Tuple/Constraint.hs
@@ -1,26 +1,19 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE Safe #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
-#if __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE NullaryTypeClasses #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE UndecidableSuperClasses #-}
-#endif
-{-# LANGUAGE Safe #-}
 
 -- | This module provides classes that emulate the behavior of GHC's constraint
 -- tuple syntax. Unlike GHC's built-in constraint tuples, the classes in this
 -- library can be partially applied.
 module Data.Tuple.Constraint
   ( -- * Constraint tuples
-#if __GLASGOW_HASKELL__ >= 708
-    CTuple0,
-#endif
-    CTuple1
+    CTuple0
+  , CTuple1
   , CTuple2
   , CTuple3
   , CTuple4
@@ -90,13 +83,11 @@ module Data.Tuple.Constraint
 #endif
   ) where
 
-#if __GLASGOW_HASKELL__ >= 708
 -- | A constraint tuple class with 0 arguments.
 --
 -- This class is only defined on GHC 7.8 or later.
 class    () => CTuple0
 instance () => CTuple0
-#endif
 
 -- | A constraint tuple class with 1 argument.
 class    c1 => CTuple1 c1

--- a/src/Data/Tuple/Constraint/ClassNewtype.hs
+++ b/src/Data/Tuple/Constraint/ClassNewtype.hs
@@ -113,6 +113,12 @@ module Data.Tuple.Constraint.ClassNewtype
   , CTuple60
   , CTuple61
   , CTuple62
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple63
+#endif
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple64
+#endif
   ) where
 
 import Data.Tuple.Constraint (CTuple1)
@@ -373,4 +379,16 @@ instance ((c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16
 -- | A constraint tuple class with 62 arguments.
 class    ((c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62) :: Constraint) => CTuple62 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62
 instance ((c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62) :: Constraint) => CTuple62 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A constraint tuple class with 63 arguments.
+class    ((c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63) :: Constraint) => CTuple63 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63
+instance ((c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63) :: Constraint) => CTuple63 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63
+#endif
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A constraint tuple class with 64 arguments.
+class    ((c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64) :: Constraint) => CTuple64 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64
+instance ((c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64) :: Constraint) => CTuple64 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64
+#endif
 

--- a/src/Data/Tuple/Constraint/ClassNewtype.hs
+++ b/src/Data/Tuple/Constraint/ClassNewtype.hs
@@ -1,20 +1,11 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE Safe #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
-#if __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE NullaryTypeClasses #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE UndecidableSuperClasses #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 800
-{-# LANGUAGE Safe #-}
-#else
-{-# LANGUAGE Trustworthy #-}
-#endif
 
 -- | This module provides classes that emulate the behavior of GHC's constraint
 -- tuple syntax. Unlike GHC's built-in constraint tuples, the classes in this
@@ -48,10 +39,8 @@
 -- construct a @Dict@ dictionary.
 module Data.Tuple.Constraint.ClassNewtype
   ( -- * Constraint tuples
-#if __GLASGOW_HASKELL__ >= 708
-    CTuple0,
-#endif
-    CTuple1
+    CTuple0
+  , CTuple1
   , CTuple2
   , CTuple3
   , CTuple4
@@ -122,19 +111,12 @@ module Data.Tuple.Constraint.ClassNewtype
   ) where
 
 import Data.Tuple.Constraint (CTuple1)
-#if __GLASGOW_HASKELL__ >= 800
 import Data.Kind (Constraint)
-#else
-import GHC.Exts (Constraint)
-#endif
-
-#if __GLASGOW_HASKELL__ >= 708
 -- | A constraint tuple class with 0 arguments.
 --
 -- This class is only defined on GHC 7.8 or later.
 class    (() :: Constraint) => CTuple0
 instance (() :: Constraint) => CTuple0
-#endif
 
 -- | A constraint tuple class with 2 arguments.
 class    ((c1, c2) :: Constraint) => CTuple2 c1 c2

--- a/src/Data/Tuple/Constraint/ClassNewtype.hs
+++ b/src/Data/Tuple/Constraint/ClassNewtype.hs
@@ -41,6 +41,8 @@ module Data.Tuple.Constraint.ClassNewtype
   ( -- * Constraint tuples
     CTuple0
   , CTuple1
+  , CUnit
+  , CSolo
   , CTuple2
   , CTuple3
   , CTuple4
@@ -110,13 +112,12 @@ module Data.Tuple.Constraint.ClassNewtype
 #endif
   ) where
 
-import Data.Tuple.Constraint (CTuple1)
+import Data.Tuple.Constraint (CTuple0, CTuple1, CSolo)
 import Data.Kind (Constraint)
+
 -- | A constraint tuple class with 0 arguments.
---
--- This class is only defined on GHC 7.8 or later.
-class    (() :: Constraint) => CTuple0
-instance (() :: Constraint) => CTuple0
+class    (() :: Constraint) => CUnit
+instance (() :: Constraint) => CUnit
 
 -- | A constraint tuple class with 2 arguments.
 class    ((c1, c2) :: Constraint) => CTuple2 c1 c2

--- a/src/Data/Tuple/Constraint/TypeFamily.hs
+++ b/src/Data/Tuple/Constraint/TypeFamily.hs
@@ -79,6 +79,12 @@ module Data.Tuple.Constraint.TypeFamily
   , CTuple60
   , CTuple61
   , CTuple62
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple63
+#endif
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple64
+#endif
   ) where
 
 import Data.Tuple.Constraint (CTuple1)
@@ -397,4 +403,18 @@ type instance Decomposer61 (f c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15
 type CTuple62 = Decomposer62 (((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) :: Constraint)
 type family   Decomposer62 (x :: Constraint) :: Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint
 type instance Decomposer62 (f c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62) = f
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A type alias for a constraint tuple with 63 arguments.
+type CTuple63 = Decomposer63 (((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) :: Constraint)
+type family   Decomposer63 (x :: Constraint) :: Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint
+type instance Decomposer63 (f c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63) = f
+#endif
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A type alias for a constraint tuple with 64 arguments.
+type CTuple64 = Decomposer64 (((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) :: Constraint)
+type family   Decomposer64 (x :: Constraint) :: Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint
+type instance Decomposer64 (f c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64) = f
+#endif
 

--- a/src/Data/Tuple/Constraint/TypeFamily.hs
+++ b/src/Data/Tuple/Constraint/TypeFamily.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE TypeFamilies #-}
-#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE Safe #-}
-#else
-{-# LANGUAGE Trustworthy #-}
-#endif
+{-# LANGUAGE TypeFamilies #-}
 
 -- | This module provides type aliases that emulate the behavior of GHC's constraint
 -- tuple syntax. Unlike GHC's built-in constraint tuples, the type aliases in this
@@ -88,12 +84,7 @@ module Data.Tuple.Constraint.TypeFamily
   ) where
 
 import Data.Tuple.Constraint (CTuple1)
-#if __GLASGOW_HASKELL__ >= 800
 import Data.Kind (Constraint)
-#else
-import GHC.Exts (Constraint)
-#endif
-
 -- | A type alias for a constraint tuple with 0 arguments.
 type CTuple0 = Decomposer0 (() :: Constraint)
 type family   Decomposer0 (x :: Constraint) :: Constraint

--- a/src/Data/Tuple/Constraint/TypeFamily.hs
+++ b/src/Data/Tuple/Constraint/TypeFamily.hs
@@ -14,6 +14,8 @@ module Data.Tuple.Constraint.TypeFamily
   ( -- * Constraint tuples
     CTuple0
   , CTuple1
+  , CUnit
+  , CSolo
   , CTuple2
   , CTuple3
   , CTuple4
@@ -83,10 +85,11 @@ module Data.Tuple.Constraint.TypeFamily
 #endif
   ) where
 
-import Data.Tuple.Constraint (CTuple1)
+import Data.Tuple.Constraint (CTuple0, CTuple1, CSolo)
 import Data.Kind (Constraint)
+
 -- | A type alias for a constraint tuple with 0 arguments.
-type CTuple0 = Decomposer0 (() :: Constraint)
+type CUnit = Decomposer0 (() :: Constraint)
 type family   Decomposer0 (x :: Constraint) :: Constraint
 type instance Decomposer0 (f ) = f
 

--- a/src/Data/Tuple/Constraint/TypeSynonym.hs
+++ b/src/Data/Tuple/Constraint/TypeSynonym.hs
@@ -93,7 +93,6 @@ import Data.Tuple.Constraint (CTuple0, CTuple1, CSolo)
 import Data.Kind (Constraint)
 import Data.Proxy (Proxy(..))
 
-
 -- | A type alias for a constraint tuple with 0 arguments.
 type CUnit = Decomposer0 ('Proxy :: Proxy (() :: Constraint))
 type Decomposer0 (x :: Proxy ((f :: Constraint) )) = f

--- a/src/Data/Tuple/Constraint/TypeSynonym.hs
+++ b/src/Data/Tuple/Constraint/TypeSynonym.hs
@@ -18,6 +18,8 @@ module Data.Tuple.Constraint.TypeSynonym
   ( -- * Constraint tuples
     CTuple0
   , CTuple1
+  , CUnit
+  , CSolo
   , CTuple2
   , CTuple3
   , CTuple4
@@ -87,12 +89,13 @@ module Data.Tuple.Constraint.TypeSynonym
 #endif
   ) where
 
-import Data.Tuple.Constraint (CTuple1)
+import Data.Tuple.Constraint (CTuple0, CTuple1, CSolo)
 import Data.Kind (Constraint)
 import Data.Proxy (Proxy(..))
 
+
 -- | A type alias for a constraint tuple with 0 arguments.
-type CTuple0 = Decomposer0 ('Proxy :: Proxy (() :: Constraint))
+type CUnit = Decomposer0 ('Proxy :: Proxy (() :: Constraint))
 type Decomposer0 (x :: Proxy ((f :: Constraint) )) = f
 
 -- | A type alias for a constraint tuple with 2 arguments.

--- a/src/Data/Tuple/Constraint/TypeSynonym.hs
+++ b/src/Data/Tuple/Constraint/TypeSynonym.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE KindSignatures #-}
-#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE Safe #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
-# if __GLASGOW_HASKELL__ < 806
+#if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
-# endif
 #endif
-{-# LANGUAGE Safe #-}
 
 -- | This module provides type aliases that emulate the behavior of GHC's constraint
 -- tuple syntax. Unlike GHC's built-in constraint tuples, the type aliases in this
@@ -16,12 +14,7 @@
 --
 -- The type aliases in this module are defined by way of type synonyms that
 -- decompose applications of constraint tuple type constructors to their arguments.
--- This requires the use of GHC capabilities that are only present on GHC 8.0 or
--- later, so this module does not export anything on earlier versions of GHC.
 module Data.Tuple.Constraint.TypeSynonym
-#if __GLASGOW_HASKELL__ < 800
-  () where
-#else
   ( -- * Constraint tuples
     CTuple0
   , CTuple1
@@ -358,4 +351,3 @@ type CTuple64 = Decomposer64 ('Proxy :: Proxy (((), (), (), (), (), (), (), (), 
 type Decomposer64 (x :: Proxy ((f :: Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint) c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64)) = f
 #endif
 
-#endif

--- a/src/Data/Tuple/Constraint/TypeSynonym.hs
+++ b/src/Data/Tuple/Constraint/TypeSynonym.hs
@@ -86,6 +86,12 @@ module Data.Tuple.Constraint.TypeSynonym
   , CTuple60
   , CTuple61
   , CTuple62
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple63
+#endif
+#if __GLASGOW_HASKELL__ >= 902
+  , CTuple64
+#endif
   ) where
 
 import Data.Tuple.Constraint (CTuple1)
@@ -339,5 +345,17 @@ type Decomposer61 (x :: Proxy ((f :: Constraint -> Constraint -> Constraint -> C
 -- | A type alias for a constraint tuple with 62 arguments.
 type CTuple62 = Decomposer62 ('Proxy :: Proxy (((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) :: Constraint))
 type Decomposer62 (x :: Proxy ((f :: Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint) c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62)) = f
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A type alias for a constraint tuple with 63 arguments.
+type CTuple63 = Decomposer63 ('Proxy :: Proxy (((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) :: Constraint))
+type Decomposer63 (x :: Proxy ((f :: Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint) c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63)) = f
+#endif
+
+#if __GLASGOW_HASKELL__ >= 902
+-- | A type alias for a constraint tuple with 64 arguments.
+type CTuple64 = Decomposer64 ('Proxy :: Proxy (((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) :: Constraint))
+type Decomposer64 (x :: Proxy ((f :: Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint -> Constraint) c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20 c21 c22 c23 c24 c25 c26 c27 c28 c29 c30 c31 c32 c33 c34 c35 c36 c37 c38 c39 c40 c41 c42 c43 c44 c45 c46 c47 c48 c49 c50 c51 c52 c53 c54 c55 c56 c57 c58 c59 c60 c61 c62 c63 c64)) = f
+#endif
 
 #endif


### PR DESCRIPTION
Fixes #2.